### PR TITLE
fix(package): react-native-swipe-gestures should be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "peerDependencies": {
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
-    "react-native": "^0.43.4",
+    "react-native": "^0.43.4"
+  },
+  "dependencies": {
     "react-native-swipe-gestures": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Shouldn't this be a dependency?  I understand that a `peerDependency` also works however shouldn't this just be a dependency since it is required to run?  Are you listing it as a peer to avoid bundling issues?  Thank you!