### PR TITLE
feat: Allow setting top offset value

### DIFF
--- a/Notification.js
+++ b/Notification.js
@@ -81,6 +81,7 @@ class Notification extends Component {
   render() {
     const {
       height,
+      topOffset=0,
       backgroundColour,
       iconApp,
       notificationBodyComponent: NotificationBody,
@@ -105,7 +106,7 @@ class Notification extends Component {
             transform: [{
               translateY: animatedValue.interpolate({
                 inputRange: [0, 1],
-                outputRange: [-height, 0],
+                outputRange: [-height+topOffset, 0],
               }),
             }],
           },


### PR DESCRIPTION
This was useful in my scenario. I had a fixed Header and a scroll view beneath it.
The Notification was showing correctly, but when swiping it down it was possible to see the empty notification container. Setting a top offset resolves the issue. I believe the best practice would be to hide/show notification instead of just animating it up.