### PR TITLE
add passProps to notificationOptions

### DIFF
--- a/src/Notification.js
+++ b/src/Notification.js
@@ -29,12 +29,13 @@ class Notification extends Component {
   }
 
   show(
-    { title, message, onPress, icon, vibrate } = {
+    { title, message, onPress, icon, vibrate, passProps } = {
       title: '',
       message: '',
       onPress: null,
       icon: null,
       vibrate: true,
+      passProps: {},
     },
   ) {
     const { closeInterval } = this.props;
@@ -53,6 +54,7 @@ class Notification extends Component {
           onPress,
           icon,
           vibrate,
+          passProps,
         },
         () => this.showNotification(() => {
           this.currentNotificationInterval = setTimeout(() => {
@@ -64,6 +66,7 @@ class Notification extends Component {
                 onPress: null,
                 icon: null,
                 vibrate: true,
+                passProps,
               },
               this.closeNotification,
             );
@@ -134,6 +137,7 @@ class Notification extends Component {
           icon={icon}
           vibrate={vibrate}
           onClose={() => this.setState({ isOpen: false }, this.closeNotification)}
+          {...this.state.passProps}
         />
       </Animated.View>
     );


### PR DESCRIPTION
This pull request adds ability to pass arbitrary props to NotificationBody component.
Props can be passed like:
```javascript
const passProps = {
  type: 'error',
};

this.props.showNotification({
  title: 'You pressed it!',
  message: 'The notification has been triggered',
  onPress: () => Alert.alert('Alert', 'You clicked the notification!'),
  passProps,
});
``` 