### PR TITLE
Add use native driver flag

### DIFF
--- a/src/Notification.js
+++ b/src/Notification.js
@@ -88,6 +88,7 @@ class Notification extends Component {
     Animated.timing(this.state.animatedValue, {
       toValue: 1,
       duration: this.props.openCloseDuration,
+      useNativeDriver: true,
     }).start(done);
   }
 
@@ -95,6 +96,7 @@ class Notification extends Component {
     Animated.timing(this.state.animatedValue, {
       toValue: 0,
       duration: this.props.openCloseDuration,
+      useNativeDriver: true,
     }).start(done);
   }
 


### PR DESCRIPTION
This flag is now required and causes warnings if not included.
Issue raised by someone else https://github.com/robcalcroft/react-native-in-app-notification/issues/19