### PR TITLE
🐛 Fix issue with disabling vibration on iOS not working

### DIFF
--- a/src/DefaultNotificationBody/index.ios.js
+++ b/src/DefaultNotificationBody/index.ios.js
@@ -70,7 +70,7 @@ class DefaultNotificationBody extends React.Component {
       StatusBar.setHidden(this.props.isOpen);
     }
 
-    if ((prevProps.vibrate || this.props.vibrate) && this.props.isOpen && !prevProps.isOpen) {
+    if (this.props.vibrate && this.props.isOpen && !prevProps.isOpen){
       Vibration.vibrate();
     }
   }


### PR DESCRIPTION
The guard was always true, making it impossible to disable the vibration.