### PR TITLE
Expose context so consumer can use with hooks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 export { default as Notification } from './Notification';
-
+export { default as Context } from './Context';
 export { default as InAppNotificationProvider } from './Provider';
 export { default as withInAppNotification } from './WithInAppNotification.hoc';


### PR DESCRIPTION
This PR should allow the library consumer to write a custom hook to expose `showNotification` using the library's internal context.  Basically, this lets us use hooks instead of the HOC which is more in line with modern practice.